### PR TITLE
feat: add OpenCode as a supported AI assistant target

### DIFF
--- a/cmd/make-decision/main.go
+++ b/cmd/make-decision/main.go
@@ -60,7 +60,7 @@ func printVersion() {
 func printUsage() {
 	fmt.Fprintln(os.Stderr, `think-better — AI-powered decision-making framework & problem-solving toolkit
 
-Install decision frameworks and critical thinking skills for Claude AI and GitHub Copilot.
+Install decision frameworks and critical thinking skills for Claude AI, GitHub Copilot, and OpenCode.
 Includes cognitive bias detection, strategic planning frameworks, and systematic problem-solving methodologies.
 
 Usage:
@@ -75,7 +75,7 @@ Commands:
   help        Show this help message
 
 Global options:
-  --ai string     AI assistant target: claude, copilot, antigravity
+  --ai string     AI assistant target: claude, copilot, antigravity, opencode
   --skill string  Skill name (default: all for init, required for uninstall)
   --force         Skip confirmation prompts
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -23,7 +23,7 @@ func RunInit(args []string) int {
 		fmt.Fprintln(os.Stderr, `Install decision-making frameworks and problem-solving skills for AI assistants.
 
 Installs cognitive bias detection, strategic planning frameworks, and critical thinking
-methodologies for Claude AI (VS Code, Claude Desktop) or GitHub Copilot.
+methodologies for Claude AI, GitHub Copilot, Antigravity, or OpenCode.
 
 Usage:
   think-better init [--ai <target>] [--skill <name>] [--force]
@@ -70,8 +70,8 @@ Flags:`)
 		return 1
 	}
 
-	// Warn if target directory doesn't exist
-	if ai != "antigravity" {
+	// Warn if target directory doesn't exist (only relevant for copilot which uses .github/)
+	if ai == "copilot" {
 		githubDir := filepath.Join(cwd, ".github")
 		if _, err := os.Stat(githubDir); os.IsNotExist(err) {
 			fmt.Fprintln(os.Stderr, "warning: .github/ directory does not exist (will be created)")
@@ -117,8 +117,14 @@ Flags:`)
 		if ai == "antigravity" {
 			fmt.Println("  - Skills installed as Antigravity skills (SKILL.md entry points)")
 			for _, s := range skillsToInstall {
-				fmt.Printf("  - Skill %q is available in .antigravity/skills/%s/\n", s.Name, s.Name)
+				fmt.Printf("  - Skill %q is available in .agents/skills/%s/\n", s.Name, s.Name)
 			}
+		} else if ai == "opencode" {
+			fmt.Println("  - Skills installed as OpenCode skills (SKILL.md entry points)")
+			for _, s := range skillsToInstall {
+				fmt.Printf("  - Skill %q is available in .opencode/skills/%s/\n", s.Name, s.Name)
+			}
+			fmt.Println("  - OpenCode will auto-discover skills via the native skill tool")
 		} else if len(skillsToInstall) == 1 {
 			fmt.Printf("  - Open your AI assistant and type /%s to start\n", skillsToInstall[0].Name)
 		} else {

--- a/internal/targets/target.go
+++ b/internal/targets/target.go
@@ -30,6 +30,11 @@ var Targets = []AITarget{
 		DisplayName:    "Antigravity (Gemini Antigravity)",
 		InstallPattern: ".agents/skills/{skill}/",
 	},
+	{
+		Name:           "opencode",
+		DisplayName:    "OpenCode",
+		InstallPattern: ".opencode/skills/{skill}/",
+	},
 }
 
 // FindTarget returns the target with the given name (case-insensitive), or nil if not found.

--- a/internal/targets/target_test.go
+++ b/internal/targets/target_test.go
@@ -10,6 +10,7 @@ func TestFindTarget(t *testing.T) {
 		{"claude", true},
 		{"copilot", true},
 		{"antigravity", true},
+		{"opencode", true},
 		{"nonexistent", false},
 		{"", false},
 	}
@@ -35,6 +36,9 @@ func TestFindTargetCaseInsensitive(t *testing.T) {
 		"COPILOT",
 		"Antigravity",
 		"ANTIGRAVITY",
+		"Opencode",
+		"OPENCODE",
+		"OpenCode",
 	}
 
 	for _, name := range tests {
@@ -66,6 +70,7 @@ func TestTargetNames(t *testing.T) {
 		"claude":      true,
 		"copilot":     true,
 		"antigravity": true,
+		"opencode":    true,
 	}
 	for _, name := range names {
 		if !expected[name] {
@@ -83,6 +88,8 @@ func TestInstallDir(t *testing.T) {
 		{"claude", "make-decision", ".claude/skills/make-decision/"},
 		{"copilot", "problem-solving-pro", ".github/prompts/problem-solving-pro/"},
 		{"antigravity", "make-decision", ".agents/skills/make-decision/"},
+		{"opencode", "make-decision", ".opencode/skills/make-decision/"},
+		{"opencode", "problem-solving-pro", ".opencode/skills/problem-solving-pro/"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Adds [OpenCode](https://opencode.ai) as a first-class AI assistant target (`--ai opencode`)
- OpenCode is an open-source terminal-first AI coding agent that discovers skills via `SKILL.md` files in `.opencode/skills/`
- Follows the same integration pattern as existing targets (Claude, Copilot, Antigravity)

## Changes

- **`internal/targets/target.go`** — Register `opencode` target with `.opencode/skills/{skill}/` install pattern
- **`internal/targets/target_test.go`** — Add test cases for target lookup, case-insensitivity, install path resolution
- **`internal/cli/init.go`** — Add opencode-specific next-steps messaging; fix `.github/` warning to only trigger for copilot
- **`cmd/make-decision/main.go`** — Update usage text to include opencode

## Usage

```bash
think-better init --ai opencode
```

Installs skills to `.opencode/skills/{skill}/` with `SKILL.md` entry points, which OpenCode auto-discovers via its native skill tool.

## Testing

All existing tests pass, new test cases added for the opencode target.