### PR TITLE
chore: add safe type hints for constants and returns (6 files)

### DIFF
--- a/.agents/skills/make-decision/scripts/core.py
+++ b/.agents/skills/make-decision/scripts/core.py
@@ -79,7 +79,7 @@ class BM25:
         tokens = text.split()
         return [t for t in tokens if len(t) > 1]
 
-    def fit(self, corpus: list):
+    def fit(self, corpus: list) -> None:
         """Build IDF index from a list of document strings."""
         self.corpus_size = len(corpus)
         if self.corpus_size == 0:

--- a/.agents/skills/make-decision/scripts/populate_data.py
+++ b/.agents/skills/make-decision/scripts/populate_data.py
@@ -6,7 +6,7 @@ import os
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-def write_csv(filename, headers, rows):
+def write_csv(filename, headers, rows) -> None:
     filepath = os.path.join(DATA_DIR, filename)
     with open(filepath, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers)
@@ -15,7 +15,7 @@ def write_csv(filename, headers, rows):
     print(f"  Written {len(rows)} rows to {filename}")
 
 
-def populate_frameworks():
+def populate_frameworks() -> None:
     headers = ["Framework", "Category", "Keywords", "Description", "When to Use", "Steps", "Strengths", "Limitations", "Best For", "Complexity"]
     rows = [
         {
@@ -142,7 +142,7 @@ def populate_frameworks():
     write_csv("decision-frameworks.csv", headers, rows)
 
 
-def populate_types():
+def populate_types() -> None:
     headers = ["Decision Type", "Keywords", "Characteristics", "Recommended Frameworks", "Analysis Methods", "Common Pitfalls", "Warning Signs", "Example Scenarios"]
     rows = [
         {
@@ -229,7 +229,7 @@ def populate_types():
     write_csv("decision-types.csv", headers, rows)
 
 
-def populate_biases():
+def populate_biases() -> None:
     headers = ["Bias", "Category", "Keywords", "Description", "Impact on Decisions", "How to Detect", "Debiasing Strategy", "Example", "Severity"]
     rows = [
         {
@@ -368,7 +368,7 @@ def populate_biases():
     write_csv("cognitive-biases.csv", headers, rows)
 
 
-def populate_analysis():
+def populate_analysis() -> None:
     headers = ["Technique", "Category", "Keywords", "Description", "When to Use", "Inputs Required", "How to Apply", "Output Format", "Strengths", "Limitations", "Complexity"]
     rows = [
         {
@@ -505,7 +505,7 @@ def populate_analysis():
     write_csv("analysis-techniques.csv", headers, rows)
 
 
-def populate_criteria():
+def populate_criteria() -> None:
     headers = ["Domain", "Keywords", "Description", "Criteria", "Default Weights", "Measurement Guidance", "Common Mistakes"]
     rows = [
         {
@@ -584,7 +584,7 @@ def populate_criteria():
     write_csv("criteria-templates.csv", headers, rows)
 
 
-def populate_facilitation():
+def populate_facilitation() -> None:
     headers = ["Technique", "Category", "Keywords", "Description", "When to Use", "Group Size", "Time Required", "Steps", "Counters Bias", "Output"]
     rows = [
         {

--- a/.agents/skills/problem-solving-pro/scripts/core.py
+++ b/.agents/skills/problem-solving-pro/scripts/core.py
@@ -69,7 +69,7 @@ CSV_CONFIG = {
 class BM25:
     """BM25 ranking algorithm for text search."""
 
-    def __init__(self, k1=1.5, b=0.75):
+    def __init__(self, k1: float=1.5, b: float=0.75):
         self.k1 = k1
         self.b = b
         self.corpus = []
@@ -84,7 +84,7 @@ class BM25:
         text = re.sub(r'[^\w\s]', ' ', str(text).lower())
         return [w for w in text.split() if len(w) > 2]
 
-    def fit(self, documents):
+    def fit(self, documents) -> None:
         """Build BM25 index from documents."""
         self.corpus = [self.tokenize(doc) for doc in documents]
         self.N = len(self.corpus)

--- a/internal/skills/skills/make-decision/scripts/core.py
+++ b/internal/skills/skills/make-decision/scripts/core.py
@@ -79,7 +79,7 @@ class BM25:
         tokens = text.split()
         return [t for t in tokens if len(t) > 1]
 
-    def fit(self, corpus: list):
+    def fit(self, corpus: list) -> None:
         """Build IDF index from a list of document strings."""
         self.corpus_size = len(corpus)
         if self.corpus_size == 0:

--- a/internal/skills/skills/make-decision/scripts/populate_data.py
+++ b/internal/skills/skills/make-decision/scripts/populate_data.py
@@ -6,7 +6,7 @@ import os
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-def write_csv(filename, headers, rows):
+def write_csv(filename, headers, rows) -> None:
     filepath = os.path.join(DATA_DIR, filename)
     with open(filepath, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=headers)
@@ -15,7 +15,7 @@ def write_csv(filename, headers, rows):
     print(f"  Written {len(rows)} rows to {filename}")
 
 
-def populate_frameworks():
+def populate_frameworks() -> None:
     headers = ["Framework", "Category", "Keywords", "Description", "When to Use", "Steps", "Strengths", "Limitations", "Best For", "Complexity"]
     rows = [
         {
@@ -142,7 +142,7 @@ def populate_frameworks():
     write_csv("decision-frameworks.csv", headers, rows)
 
 
-def populate_types():
+def populate_types() -> None:
     headers = ["Decision Type", "Keywords", "Characteristics", "Recommended Frameworks", "Analysis Methods", "Common Pitfalls", "Warning Signs", "Example Scenarios"]
     rows = [
         {
@@ -229,7 +229,7 @@ def populate_types():
     write_csv("decision-types.csv", headers, rows)
 
 
-def populate_biases():
+def populate_biases() -> None:
     headers = ["Bias", "Category", "Keywords", "Description", "Impact on Decisions", "How to Detect", "Debiasing Strategy", "Example", "Severity"]
     rows = [
         {
@@ -368,7 +368,7 @@ def populate_biases():
     write_csv("cognitive-biases.csv", headers, rows)
 
 
-def populate_analysis():
+def populate_analysis() -> None:
     headers = ["Technique", "Category", "Keywords", "Description", "When to Use", "Inputs Required", "How to Apply", "Output Format", "Strengths", "Limitations", "Complexity"]
     rows = [
         {
@@ -505,7 +505,7 @@ def populate_analysis():
     write_csv("analysis-techniques.csv", headers, rows)
 
 
-def populate_criteria():
+def populate_criteria() -> None:
     headers = ["Domain", "Keywords", "Description", "Criteria", "Default Weights", "Measurement Guidance", "Common Mistakes"]
     rows = [
         {
@@ -584,7 +584,7 @@ def populate_criteria():
     write_csv("criteria-templates.csv", headers, rows)
 
 
-def populate_facilitation():
+def populate_facilitation() -> None:
     headers = ["Technique", "Category", "Keywords", "Description", "When to Use", "Group Size", "Time Required", "Steps", "Counters Bias", "Output"]
     rows = [
         {

--- a/internal/skills/skills/problem-solving-pro/scripts/core.py
+++ b/internal/skills/skills/problem-solving-pro/scripts/core.py
@@ -69,7 +69,7 @@ CSV_CONFIG = {
 class BM25:
     """BM25 ranking algorithm for text search."""
 
-    def __init__(self, k1=1.5, b=0.75):
+    def __init__(self, k1: float=1.5, b: float=0.75):
         self.k1 = k1
         self.b = b
         self.corpus = []
@@ -84,7 +84,7 @@ class BM25:
         text = re.sub(r'[^\w\s]', ' ', str(text).lower())
         return [w for w in text.split() if len(w) > 2]
 
-    def fit(self, documents):
+    def fit(self, documents) -> None:
         """Build BM25 index from documents."""
         self.corpus = [self.tokenize(doc) for doc in documents]
         self.N = len(self.corpus)


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be slightly improved. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `.agents/skills/make-decision/scripts/core.py`: added type hints to 1 function(s)
- `.agents/skills/make-decision/scripts/populate_data.py`: added type hints to 7 function(s)
- `.agents/skills/problem-solving-pro/scripts/core.py`: added type hints to 2 function(s)
- `internal/skills/skills/make-decision/scripts/core.py`: added type hints to 1 function(s)
- `internal/skills/skills/make-decision/scripts/populate_data.py`: added type hints to 7 function(s)
- `internal/skills/skills/problem-solving-pro/scripts/core.py`: added type hints to 2 function(s)

I have added **strictly conservative** type annotations based only on explicit primitive default values and singular return statements. Complex objects and dynamic references were purposefully ignored to avoid false positives.

### Examples of changes
**Example change in `.agents/skills/make-decision/scripts/core.py`:**
```diff
-    def fit(self, corpus: list):
+    def fit(self, corpus: list) -> None:
```
**Example change in `.agents/skills/make-decision/scripts/populate_data.py`:**
```diff
-def write_csv(filename, headers, rows):
+def write_csv(filename, headers, rows) -> None:
-def populate_frameworks():
+def populate_frameworks() -> None:
-def populate_types():
+def populate_types() -> None:
-def populate_biases():
+def populate_biases() -> None:
-def populate_analysis():
+def populate_analysis() -> None:
-def populate_criteria():
+def populate_criteria() -> None:
... (truncated for brevity)
```

---
### Verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- I did not modify any `__init__.py` files.

If anything looks incorrect, please feel free to adjust it or close the PR entirely. Thank you for maintaining this project!